### PR TITLE
Add flag to listen on 0.0.0.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
@@ -15,10 +14,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 issues:
   exclude-use-default: false

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ should output
 
 Which exposes the [go-da] interface over JSONRPC and can be accessed with an HTTP client like [xh][xh]:
 
+You can also run mock-da with a `-listen-all` flag which will make the process listen on 0.0.0.0 so that it can be accessed from other machines.
+
+```sh
+$ ./mock-da -listen-all
+2024/04/11 12:23:34 Listening on: 0.0.0.0:7980
+```
+
 ### MaxBlobSize
 
 ```sh

--- a/cmd/mock-da/main.go
+++ b/cmd/mock-da/main.go
@@ -15,16 +15,25 @@ import (
 )
 
 const (
-	// MockDAAddress is the mock address for the gRPC server
-	MockDAAddress = "grpc://localhost:7980"
+	// MockDAPort is the port used for the mock DA gRPC server
+	MockDAPort = 7980
 )
+
+var listenAll = flag.Bool("listen-all", false, "Listen on all network interfaces (0.0.0.0) instead of just localhost")
 
 func main() {
 	var (
 		host string
 		port string
 	)
-	addr, _ := url.Parse(MockDAAddress)
+	flag.Parse()
+        ip := "localhost"
+        if *listenAll {
+            ip = "0.0.0.0"
+        }
+	address := fmt.Sprintf("grpc://%s:%d", ip, MockDAPort)
+
+	addr, _ := url.Parse(address)
 	flag.StringVar(&port, "port", addr.Port(), "listening port")
 	flag.StringVar(&host, "host", addr.Hostname(), "listening address")
 	flag.Parse()

--- a/cmd/mock-da/main.go
+++ b/cmd/mock-da/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -15,28 +14,24 @@ import (
 )
 
 const (
-	// MockDAPort is the port used for the mock DA gRPC server
-	MockDAPort = 7980
+	defaultHost = "localhost"
+	defaultPort = "7980"
 )
-
-var listenAll = flag.Bool("listen-all", false, "Listen on all network interfaces (0.0.0.0) instead of just localhost")
 
 func main() {
 	var (
-		host string
-		port string
+		host      string
+		port      string
+		listenAll bool
 	)
+	flag.StringVar(&port, "port", defaultPort, "listening port")
+	flag.StringVar(&host, "host", defaultHost, "listening address")
+	flag.BoolVar(&listenAll, "listen-all", false, "listen on all network interfaces (0.0.0.0) instead of just localhost")
 	flag.Parse()
-        ip := "localhost"
-        if *listenAll {
-            ip = "0.0.0.0"
-        }
-	address := fmt.Sprintf("grpc://%s:%d", ip, MockDAPort)
 
-	addr, _ := url.Parse(address)
-	flag.StringVar(&port, "port", addr.Port(), "listening port")
-	flag.StringVar(&host, "host", addr.Hostname(), "listening address")
-	flag.Parse()
+	if listenAll {
+		host = "0.0.0.0"
+	}
 
 	srv := proxy.NewServer(host, port, goDATest.NewDummyDA())
 	log.Printf("Listening on: %s:%s", host, port)


### PR DESCRIPTION
I wanted to run mock-da with interchaintest as a sidecar, but quickly (not quickly enough) found out that the process only listens on localhost. So I had to make a little adjustment to support listening on 0.0.0.0 so that it would be accessible between containers.

If you want this change, here it is :) I updated the readme as well to document the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `-listen-all` flag for `mock-da` to enable listening on all network interfaces, allowing access from other machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->