### PR TITLE
feat(ci): add docker build and publish ci

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: rollkit/.github/.github/workflows/reusable_dockerfile_pipeline.yml@update-docker
+    uses: rollkit/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.0
     with:
       dockerfile: Dockerfile
     secrets: inherit

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,0 +1,26 @@
+name: docker-build-publish
+
+# Trigger on all push events, new semantic version tags, and all PRs
+on:
+  push:
+    branches:
+      - "main"
+      - "v[0-9].[0-9].x"
+      - "v[0-9].[0-9][0-9].x"
+      - "v[0-9].x"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+  pull_request:
+
+jobs:
+  docker-build:
+    permissions:
+      contents: write
+      packages: write
+    uses: rollkit/.github/.github/workflows/reusable_dockerfile_pipeline.yml@update-docker
+    with:
+      dockerfile: Dockerfile
+    secrets: inherit

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+---
+# Built from docs https://yamllint.readthedocs.io/en/stable/configuration.html
+extends: default
+
+rules:
+  # 120 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 120
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: vet
 	@echo "--> Running markdownlint"
 	@markdownlint --config .markdownlint.yaml '**/*.md'
 	@echo "--> Running hadolint"
-	@hadolint docker/mockserv.Dockerfile
+	@hadolint Dockerfile
 	@echo "--> Running yamllint"
 	@yamllint --no-warnings . -c .yamllint.yml
 


### PR DESCRIPTION
## Overview

Pending https://github.com/rollkit/.github/pull/12 getting merged in so that we can target a release and not a branch. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a workflow for building and publishing Docker images.
  - Added a YAML configuration file to extend default linting rules.
  - Updated `Makefile` to use the main Dockerfile for linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->